### PR TITLE
fix: standardize api specification

### DIFF
--- a/src/Ambev.DeveloperEvaluation.WebApi/Common/ApiErrorsConventionHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Common/ApiErrorsConventionHandler.cs
@@ -11,22 +11,18 @@ internal sealed class ApiErrorsConventionHandler
     /// <summary>
     /// Occurs when not found resource by route.
     /// </summary>
-    private static readonly object ResourceNotFoundErrorResponse = new
-    {
-        Type = ApiResponseErrorType.ResourceNotFound.ToString(),
-        Error = "Uri not found",
-        Detail = "Endpoint does not exist",
-    };
+    private static readonly ApiResponse ResourceNotFoundErrorResponse = ApiResponse.CreateError(
+        ApiResponseErrorType.ResourceNotFound,
+        "Uri not found",
+        "Endpoint does not exist");
 
     /// <summary>
     /// Occurs when authentication failed.
     /// </summary>
-    private static readonly object AuthenticationErrorResponse = new
-    {
-        Type = ApiResponseErrorType.AuthenticationError.ToString(),
-        Error = "Invalid authentication token",
-        Detail = "The provided authentication token has expired or is invalid",
-    };
+    private static readonly ApiResponse AuthenticationErrorResponse = ApiResponse.CreateError(
+        ApiResponseErrorType.AuthenticationError,
+        "Invalid authentication token",
+        "The provided authentication token has expired or is invalid");
 
     /// <summary>
     /// Handle bad request when is invalid mvc model validation.
@@ -36,12 +32,9 @@ internal sealed class ApiErrorsConventionHandler
     public static IActionResult HandleBadRequestOnInvalidModelValidation(ActionContext context)
     {
         var error = context.ModelState.FirstOrDefault(_ => _.Key.StartsWith('$'), context.ModelState.FirstOrDefault());
-        var problemDetails = new
-        {
-            Type = ApiResponseErrorType.ValidationError.ToString(),
-            Error = "Invalid input data",
-            Detail = error.Value?.Errors.Select(e => e.ErrorMessage).FirstOrDefault() ?? "Error",
-        };
+        var problemDetails = ApiResponse.CreateAsValidationError(
+            "Invalid input data",
+            error.Value?.Errors.Select(e => e.ErrorMessage).FirstOrDefault() ?? "Error");
 
         return new BadRequestObjectResult(problemDetails);
     }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Common/ApiErrorsConventionHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Common/ApiErrorsConventionHandler.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ambev.DeveloperEvaluation.WebApi.Common;
+
+/// <summary>
+/// Defines way to convention response api error.
+/// </summary>
+internal sealed class ApiErrorsConventionHandler
+{
+    /// <summary>
+    /// Occurs when not found resource by route.
+    /// </summary>
+    private static readonly object ResourceNotFoundErrorResponse = new
+    {
+        Type = ApiResponseErrorType.ResourceNotFound.ToString(),
+        Error = "Uri not found",
+        Detail = "Endpoint does not exist",
+    };
+
+    /// <summary>
+    /// Occurs when authentication failed.
+    /// </summary>
+    private static readonly object AuthenticationErrorResponse = new
+    {
+        Type = ApiResponseErrorType.AuthenticationError.ToString(),
+        Error = "Invalid authentication token",
+        Detail = "The provided authentication token has expired or is invalid",
+    };
+
+    /// <summary>
+    /// Handle bad request when is invalid mvc model validation.
+    /// </summary>
+    /// <param name="context">Action context</param>
+    /// <returns>Action result</returns>
+    public static IActionResult HandleBadRequestOnInvalidModelValidation(ActionContext context)
+    {
+        var error = context.ModelState.FirstOrDefault(_ => _.Key.StartsWith('$'), context.ModelState.FirstOrDefault());
+        var problemDetails = new
+        {
+            Type = ApiResponseErrorType.ValidationError.ToString(),
+            Error = "Invalid input data",
+            Detail = error.Value?.Errors.Select(e => e.ErrorMessage).FirstOrDefault() ?? "Error",
+        };
+
+        return new BadRequestObjectResult(problemDetails);
+    }
+
+    /// <summary>
+    /// Handle error by status code.
+    /// </summary>
+    /// <param name="context">Status code context</param>
+    /// <returns>Asynchronous task.</returns>
+    public static Task HandleByStatusCode(StatusCodeContext context)
+    {
+        var errorResponse = context.HttpContext.Response.StatusCode switch
+        {
+            StatusCodes.Status401Unauthorized => AuthenticationErrorResponse,
+            StatusCodes.Status404NotFound => ResourceNotFoundErrorResponse,
+            _ => null,
+        };
+
+        return context.HttpContext.Response.WriteAsJsonAsync(errorResponse);
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Common/ApiResponse.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Common/ApiResponse.cs
@@ -5,6 +5,46 @@ namespace Ambev.DeveloperEvaluation.WebApi.Common;
 public class ApiResponse
 {
     public bool Success { get; set; }
+    public string Type { get; private set; } = ApiResponseErrorType.ValidationError.ToString();
     public string Message { get; set; } = string.Empty;
     public IEnumerable<ValidationErrorDetail> Errors { get; set; } = [];
+
+    public static ApiResponse CreateAsValidationError(string error, string detail) =>
+        CreateAsValidationError([
+            new()
+            {
+                Error = error,
+                Detail = detail,
+            }
+        ]);
+
+    public static ApiResponse CreateAsValidationError(IEnumerable<ValidationErrorDetail> errors) => new()
+    {
+        Success = false,
+        Type = ApiResponseErrorType.ValidationError.ToString(),
+        Message = "Validation Failed",
+        Errors = errors,
+    };
+
+    public static ApiResponse CreateAsNotFound(string error, string detail) => new()
+    {
+        Success = false,
+        Type = ApiResponseErrorType.ResourceNotFound.ToString(),
+        Message = error,
+        Errors =
+        [
+            new()
+            {
+                Error = error,
+                Detail = detail,
+            },
+        ],
+    };
+
+    public static ApiResponse CreateAsNotFound(string message = "Resource not found") => new()
+    {
+        Success = false,
+        Type = ApiResponseErrorType.ResourceNotFound.ToString(),
+        Message = message,
+    };
 }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Common/ApiResponse.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Common/ApiResponse.cs
@@ -10,7 +10,20 @@ public class ApiResponse
     public IEnumerable<ValidationErrorDetail> Errors { get; set; } = [];
 
     public static ApiResponse CreateAsValidationError(string error, string detail) =>
-        CreateAsValidationError([
+        CreateError(ApiResponseErrorType.ValidationError, error, detail);
+
+    public static ApiResponse CreateAsValidationError(IEnumerable<ValidationErrorDetail> errors) =>
+        CreateError(ApiResponseErrorType.ValidationError, errors);
+
+    public static ApiResponse CreateAsNotFound(string error, string detail) =>
+        CreateError(ApiResponseErrorType.ResourceNotFound, error, detail);
+
+    public static ApiResponse CreateAsNotFound(string message = "Resource not found") =>
+        CreateError(ApiResponseErrorType.ResourceNotFound, message, string.Empty);
+
+    public static ApiResponse CreateError(ApiResponseErrorType type, string error, string detail) =>
+        CreateError(type,
+        [
             new()
             {
                 Error = error,
@@ -18,33 +31,11 @@ public class ApiResponse
             }
         ]);
 
-    public static ApiResponse CreateAsValidationError(IEnumerable<ValidationErrorDetail> errors) => new()
+    public static ApiResponse CreateError(ApiResponseErrorType type, IEnumerable<ValidationErrorDetail> errors) => new()
     {
         Success = false,
-        Type = ApiResponseErrorType.ValidationError.ToString(),
-        Message = "Validation Failed",
+        Type = type.ToString(),
+        Message = errors.FirstOrDefault()?.Error ?? "Validation Failed",
         Errors = errors,
-    };
-
-    public static ApiResponse CreateAsNotFound(string error, string detail) => new()
-    {
-        Success = false,
-        Type = ApiResponseErrorType.ResourceNotFound.ToString(),
-        Message = error,
-        Errors =
-        [
-            new()
-            {
-                Error = error,
-                Detail = detail,
-            },
-        ],
-    };
-
-    public static ApiResponse CreateAsNotFound(string message = "Resource not found") => new()
-    {
-        Success = false,
-        Type = ApiResponseErrorType.ResourceNotFound.ToString(),
-        Message = message,
     };
 }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Common/ApiResponseErrorType.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Common/ApiResponseErrorType.cs
@@ -1,0 +1,27 @@
+﻿namespace Ambev.DeveloperEvaluation.WebApi.Common;
+
+/// <summary>
+/// Defines types response error.
+/// </summary>
+public enum ApiResponseErrorType
+{
+    /// <summary>
+    /// No erros.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Resource not found.
+    /// </summary>
+    ResourceNotFound,
+
+    /// <summary>
+    /// Authentication error.
+    /// </summary>
+    AuthenticationError,
+
+    /// <summary>
+    /// Validation error.
+    /// </summary>
+    ValidationError,
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Common/BaseController.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Common/BaseController.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Ambev.DeveloperEvaluation.Common.Validation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Ambev.DeveloperEvaluation.WebApi.Common;
 
@@ -7,27 +9,27 @@ namespace Ambev.DeveloperEvaluation.WebApi.Common;
 public abstract class BaseController : ControllerBase
 {
     protected IActionResult Ok<T>(T data, string? message = default) =>
-            base.Ok(new ApiResponseWithData<T> { Data = data, Success = true, Message = message ?? string.Empty });
+        base.Ok(new ApiResponseWithData<T> { Data = data, Success = true, Message = message ?? string.Empty });
 
     protected IActionResult Ok(string message) =>
-            base.Ok(new ApiResponseWithData<object> { Data = null, Success = true, Message = message });
+        base.Ok(new ApiResponseWithData<object> { Data = null, Success = true, Message = message });
 
     protected IActionResult Created<T>(string routeName, object routeValues, T data, string? message = default) =>
         base.CreatedAtRoute(routeName, routeValues, new ApiResponseWithData<T> { Data = data, Success = true, Message = message ?? string.Empty });
 
-    protected IActionResult BadRequest(string message) =>
-        base.BadRequest(new ApiResponse { Message = message, Success = false });
+    protected IActionResult BadRequest(List<ValidationFailure> errors) =>
+        base.BadRequest(ApiResponse.CreateAsValidationError(errors.Select(ValidationErrorDetail.ConvertFrom)));
 
     protected IActionResult NotFound(string message = "Resource not found") =>
-        base.NotFound(new ApiResponse { Message = message, Success = false });
+        base.NotFound(ApiResponse.CreateAsNotFound(message));
 
     protected IActionResult OkPaginated<T>(PaginatedList<T> pagedList) =>
-            base.Ok(new PaginatedResponse<T>
-            {
-                Data = pagedList,
-                CurrentPage = pagedList.CurrentPage,
-                TotalPages = pagedList.TotalPages,
-                TotalItems = pagedList.TotalCount,
-                Success = true
-            });
+        base.Ok(new PaginatedResponse<T>
+        {
+            Data = pagedList,
+            CurrentPage = pagedList.CurrentPage,
+            TotalPages = pagedList.TotalPages,
+            TotalItems = pagedList.TotalCount,
+            Success = true
+        });
 }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Carts/CartsController.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Carts/CartsController.cs
@@ -20,6 +20,7 @@ namespace Ambev.DeveloperEvaluation.WebApi.Features.Carts;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
+[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status401Unauthorized)]
 public class CartsController : BaseController
 {
     private readonly IMediator _mediator;

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Carts/DeleteCart/DeleteCartRequest.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Carts/DeleteCart/DeleteCartRequest.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Mvc;
+
 namespace Ambev.DeveloperEvaluation.WebApi.Features.Carts.DeleteCart;
 
 /// <summary>
@@ -8,5 +10,6 @@ public class DeleteCartRequest
     /// <summary>
     /// The unique identifier of the cart to delete
     /// </summary>
+    [FromRoute(Name = "id")]
     public Guid Id { get; set; }
 }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Carts/UpdateCart/UpdateCartRequest.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Carts/UpdateCart/UpdateCartRequest.cs
@@ -8,7 +8,7 @@ public class UpdateCartRequest
     /// <summary>
     /// The unique identifier of the product to update.
     /// </summary>
-    public Guid Id { get; set; }
+    public Guid Id { get; private set; }
 
     /// <summary>
     /// Gets a customer who bought a cart.
@@ -29,4 +29,15 @@ public class UpdateCartRequest
     /// Gets products in the cart.
     /// </summary>
     public ICollection<UpdateCartItemRequest> Products { get; set; } = [];
+
+    /// <summary>
+    /// Associate id to request.
+    /// </summary>
+    /// <param name="id">Identifier</param>
+    /// <returns>Instance <see cref="UpdateCartRequest"/> of request.</returns>
+    public UpdateCartRequest WithId(Guid id)
+    {
+        Id = id;
+        return this;
+    }
 }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Products/ProductsController.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Products/ProductsController.cs
@@ -23,6 +23,7 @@ namespace Ambev.DeveloperEvaluation.WebApi.Features.Products;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
+[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status401Unauthorized)]
 public class ProductsController : BaseController
 {
     private readonly IMediator _mediator;

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Products/ProductsController.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Products/ProductsController.cs
@@ -115,10 +115,12 @@ public class ProductsController : BaseController
     [HttpPut("{id}")]
     [ProducesResponseType(typeof(ApiResponseWithData<ProductResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> UpdateProduct(Guid id, [FromBody] UpdateProductRequest request, CancellationToken cancellationToken)
+    public async Task<IActionResult> UpdateProduct(
+        [FromRoute] Guid id,
+        [FromBody] UpdateProductRequest request,
+        CancellationToken cancellationToken)
     {
-        if (id != request.Id)
-            return BadRequest("The request id is different from the url");
+        request.WithId(id);
 
         var validator = new UpdateProductRequestValidator();
         var validationResult = await validator.ValidateAsync(request, cancellationToken);

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Products/UpdateProduct/UpdateProductRequest.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Products/UpdateProduct/UpdateProductRequest.cs
@@ -10,7 +10,7 @@ public class UpdateProductRequest
     /// <summary>
     /// The unique identifier of the product to update.
     /// </summary>
-    public Guid Id { get; set; }
+    public Guid Id { get; private set; }
 
     /// <summary>
     /// Gets the product's title. Must be unique and contain only valid characters.
@@ -41,4 +41,15 @@ public class UpdateProductRequest
     /// Gets the product's category name.
     /// </summary>
     public string Category { get; set; } = default!;
+
+    /// <summary>
+    /// Associate id to request.
+    /// </summary>
+    /// <param name="id">Identifier</param>
+    /// <returns>Instance <see cref="UpdateProductRequest"/> of request.</returns>
+    public UpdateProductRequest WithId(Guid id)
+    {
+        Id = id;
+        return this;
+    }
 }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/DeleteUser/DeleteUserRequest.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/DeleteUser/DeleteUserRequest.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Mvc;
+
 namespace Ambev.DeveloperEvaluation.WebApi.Features.Users.DeleteUser;
 
 /// <summary>
@@ -8,5 +10,6 @@ public class DeleteUserRequest
     /// <summary>
     /// The unique identifier of the user to delete
     /// </summary>
+    [FromRoute(Name = "id")]
     public Guid Id { get; set; }
 }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/UsersController.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/UsersController.cs
@@ -92,9 +92,8 @@ public class UsersController : BaseController
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeleteUser([FromRoute] Guid id, CancellationToken cancellationToken)
+    public async Task<IActionResult> DeleteUser(DeleteUserRequest request, CancellationToken cancellationToken)
     {
-        var request = new DeleteUserRequest { Id = id };
         var validator = new DeleteUserRequestValidator();
         var validationResult = await validator.ValidateAsync(request, cancellationToken);
 

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/UsersController.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Users/UsersController.cs
@@ -16,6 +16,7 @@ namespace Ambev.DeveloperEvaluation.WebApi.Features.Users;
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
+[ProducesResponseType(typeof(ApiResponse), StatusCodes.Status401Unauthorized)]
 public class UsersController : BaseController
 {
     private readonly IMediator _mediator;

--- a/src/Ambev.DeveloperEvaluation.WebApi/Middleware/ValidationExceptionMiddleware.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Middleware/ValidationExceptionMiddleware.cs
@@ -1,8 +1,8 @@
 ﻿using Ambev.DeveloperEvaluation.Common.Validation;
+using Ambev.DeveloperEvaluation.Domain.Exceptions;
 using Ambev.DeveloperEvaluation.WebApi.Common;
 using FluentValidation;
 using System.Net.Mime;
-using System.Text.Json;
 
 namespace Ambev.DeveloperEvaluation.WebApi.Middleware
 {
@@ -23,29 +23,27 @@ namespace Ambev.DeveloperEvaluation.WebApi.Middleware
             }
             catch (ValidationException ex)
             {
-                await HandleValidationExceptionAsync(context, ex);
+                var response = ApiResponse.CreateAsValidationError(ex.Errors.Select(error => (ValidationErrorDetail)error));
+                await WriteResponseAsync(context, response);
+            }
+            catch (NotFoundDomainException ex)
+            {
+                var response = ApiResponse.CreateAsNotFound(ex.Error, ex.Detail);
+                await WriteResponseAsync(context, response);
+            }
+            catch (DomainException ex)
+            {
+                var response = ApiResponse.CreateAsValidationError("Bussines rules failure", ex.Message);
+                await WriteResponseAsync(context, response);
             }
         }
 
-        private static Task HandleValidationExceptionAsync(HttpContext context, ValidationException exception)
+        private static Task WriteResponseAsync(HttpContext context, ApiResponse response)
         {
             context.Response.ContentType = MediaTypeNames.Application.Json;
             context.Response.StatusCode = StatusCodes.Status400BadRequest;
 
-            var response = new ApiResponse
-            {
-                Success = false,
-                Message = "Validation Failed",
-                Errors = exception.Errors
-                    .Select(error => (ValidationErrorDetail)error)
-            };
-
-            var jsonOptions = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            };
-
-            return context.Response.WriteAsync(JsonSerializer.Serialize(response, jsonOptions));
+            return context.Response.WriteAsJsonAsync(response);
         }
     }
 }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Program.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Program.cs
@@ -7,6 +7,7 @@ using Ambev.DeveloperEvaluation.WebApi.Middleware;
 using Ambev.DeveloperEvaluation.WebApi.Startups;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
+using System.Text.Json.Serialization;
 
 namespace Ambev.DeveloperEvaluation.WebApi;
 
@@ -22,6 +23,12 @@ public class Program
             builder.AddDefaultLogging();
 
             builder.Services.AddControllers();
+                .AddJsonOptions(options =>
+                {
+                    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+                    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+                });
+
             builder.Services.AddEndpointsApiExplorer();
 
             builder.AddBasicHealthChecks();
@@ -45,7 +52,6 @@ public class Program
             if (app.Environment.IsDevelopment())
             {
                 app.UseSwagger();
-                app.UseSwaggerUI();
             }
 
             app.UseHttpsRedirection();

--- a/src/Ambev.DeveloperEvaluation.WebApi/Startups/SwaggerStartup.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Startups/SwaggerStartup.cs
@@ -25,6 +25,15 @@ namespace Ambev.DeveloperEvaluation.WebApi.Startups
             });
         }
 
+        public static void UseSwagger(this IApplicationBuilder app)
+        {
+            app.UseSwagger(o =>
+            {
+                o.PreSerializeFilters.Add(UseLowerCaseRoutingConventionFilter);
+            });
+            app.UseSwaggerUI();
+        }
+
         private static void AddSecurity(this SwaggerGenOptions swaggerOptions)
         {
             const string bearer = "Bearer";
@@ -56,6 +65,17 @@ namespace Ambev.DeveloperEvaluation.WebApi.Startups
                     Array.Empty<string>()
                 },
             });
+        }
+
+        private static void UseLowerCaseRoutingConventionFilter(OpenApiDocument document, HttpRequest request)
+        {
+            var paths = document.Paths.ToDictionary(item => item.Key.ToLowerInvariant(), item => item.Value);
+            document.Paths.Clear();
+
+            foreach (var pathItem in paths)
+            {
+                document.Paths.Add(pathItem.Key, pathItem.Value);
+            }
         }
     }
 }


### PR DESCRIPTION
## Error Handling

The API uses conventional HTTP response codes to indicate the success or failure of an API request. In general:

- 2xx range indicate success
- 4xx range indicate an error that failed given the information provided (e.g., a required parameter was omitted, etc.)
- 5xx range indicate an error with our servers

### Error Response Format

```json
{
  "success": "boolean",
  "type": "string",
  "message": "string",
  "errors": "array"
}
```
- `success`: Indicates success of operation
- `type`: A machine-readable error type identifier
- `message`: A short, human-readable summary of the problem
- `errors`: array of:
  - `error`: A short, human-readable summary of the problem
  - `detail`: A human-readable explanation specific to this occurrence of the problem

Example error responses:

1. Resource Not Found
```json
{
  "success": false,
  "type": "ResourceNotFound",
  "message": "Product not found",
  "errors": [
    {
        "error": "Product not found",
        "detail": "The product with ID 12345 does not exist in our database"
    }
  ]
}
```

2. Authentication Error
```json
{
  "success": false,
  "type": "AuthenticationError",
  "message": "Invalid authentication token",
  "errors": [
    {
      "error": "Invalid authentication token",
      "detail": "The provided authentication token has expired or is invalid"
    }
  ]
}
```

3. Validation Error
```json
{
  "success": false,
  "type": "ValidationError",
  "message": "Invalid input data",
  "errors": [
    {
      "error": "Invalid input data",
      "detail": "The 'price' field must be a positive number"
    }
  ]
}
```